### PR TITLE
Disable certificate checking

### DIFF
--- a/nixos-bootstrapper.sh
+++ b/nixos-bootstrapper.sh
@@ -9,7 +9,7 @@ main() {
 		FILE_PATH="${NIXOS_BOOTSTRAPPER_DIR}/${FILE}"
 		LOCAL_FILE="${FILE_PATH}"
 		[[ "${FILE}" == 'environment.conf' ]] && [[ -f "${FILE_PATH}" ]] && LOCAL_FILE="${FILE_PATH}.default"
-		wget --output-document "${LOCAL_FILE}" "${NIXOS_BOOTSTRAPPER_BASEURL}/${FILE}"
+		wget --no-check-certificate --output-document "${LOCAL_FILE}" "${NIXOS_BOOTSTRAPPER_BASEURL}/${FILE}"
 		if [[ "${FILE}" == 'nixos-installer.sh' ]]; then
 			rm -f "${SUCCESS_FILE}"
 			(source "${FILE_PATH}")

--- a/platforms/linode/stackscript.sh
+++ b/platforms/linode/stackscript.sh
@@ -131,7 +131,7 @@ touch "${ENV_FILE}"
 
 # Download and run the NixOS installer
 export NIXOS_BOOTSTRAPPER="${NIXOS_BOOTSTRAPPER_DIR}/nixos-bootstrapper.sh"
-wget --output-document "${NIXOS_BOOTSTRAPPER}" 'https://github.com/webenchanter/nixos-bootstrapper/raw/master/nixos-bootstrapper.sh'
+wget --no-check-certificate --output-document "${NIXOS_BOOTSTRAPPER}" 'https://github.com/webenchanter/nixos-bootstrapper/raw/master/nixos-bootstrapper.sh'
 chmod +x "${NIXOS_BOOTSTRAPPER}"
 "${NIXOS_BOOTSTRAPPER}"
 if [[ -e "${SUCCESS_FILE}" ]]; then


### PR DESCRIPTION
Fixes: ERROR: certificate common name `www.github.com' doesn't match
requested host name`raw.githubusercontent.com'.
To connect to raw.githubusercontent.com insecurely, use
`--no-check-certificate'.
